### PR TITLE
feat(backtest): add Phase IV vectorized backtester skeleton + smoke CI

### DIFF
--- a/.github/workflows/backtest_smoke.yml
+++ b/.github/workflows/backtest_smoke.yml
@@ -1,0 +1,35 @@
+name: Backtest smoke
+
+on:
+  push:
+    branches:
+      - feat/backtest-phase4
+  pull_request:
+    branches:
+      - feat/backtest-phase4
+
+jobs:
+  backtest-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-backtest.txt
+
+      - name: Run smoke backtest
+        run: |
+          python scripts/run_backtest.py --sample --outdir artifacts/backtest/smoke_run
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: backtest-smoke-artifacts
+          path: artifacts/backtest/smoke_run

--- a/configs/trade_logic.yaml
+++ b/configs/trade_logic.yaml
@@ -1,0 +1,20 @@
+# Trade logic + backtest defaults
+fees:
+  maker: 0.0002   # 0.02%
+  taker: 0.0004   # 0.04%
+
+slippage:
+  alpha: 0.5      # execution price = next_open + alpha * ATR_next
+
+execution:
+  mode: "long-only" # long-only | long-short
+  min_notional: 10.0
+
+backtest:
+  signal_to_position:
+    BUY: 1
+    SELL: -1
+    FLAT: 0
+
+logging:
+  level: INFO

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -1,0 +1,42 @@
+# Backtesting & Phase IV — Vectorized Backtester (phenol Phase 4 scaffold)
+
+This module provides a vectorized backtester skeleton and a smoke CI workflow.
+
+Files added:
+- `src/backtest/backtester.py` — vectorized backtester (pandas).
+- `scripts/run_backtest.py` — CLI runner for local/backtest runs.
+- `configs/trade_logic.yaml` — default config for fees/slippage/execution.
+- `.github/workflows/backtest_smoke.yml` — smoke GitHub Action.
+
+Outputs:
+- `artifacts/backtest/equity_curve.csv`
+- `artifacts/backtest/trades.csv`
+- `artifacts/backtest/summary.json`
+
+Execution (local):
+```bash
+pip install -r requirements-backtest.txt
+python scripts/run_backtest.py --input /data/cleaned/BTCUSD_1min.cleaned.csv --outdir artifacts/backtest/run_YYYYMMDD_HHMM
+```
+
+Notes:
+
+The backtester assumes minute OHLCV and uses the next-bar open as base execution price,
+with configurable slippage = alpha * ATR_next_bar.
+
+Fees are applied per trade (maker/taker). Execution mode and min_notional are configurable.
+
+This is a skeleton suitable for extension: Monte Carlo reshuffles, walk-forward loops,
+parameter sweeps, and more robust slippage/limit-order filling models should be added next.
+
+
+---
+
+### `requirements-backtest.txt`
+
+
+pandas>=2.0
+numpy>=1.25
+pyyaml
+scipy
+statsmodels

--- a/requirements-backtest.txt
+++ b/requirements-backtest.txt
@@ -1,0 +1,5 @@
+pandas>=2.0
+numpy>=1.25
+pyyaml
+scipy
+statsmodels

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -1,31 +1,68 @@
 #!/usr/bin/env python3
 """
-Convenience runner for Phase IV backtester scaffold.
-
-Usage:
-  python scripts/run_backtest.py --config configs/backtest.yaml
+Simple runner for the backtester skeleton. Supports --sample to run a small generated dataset
+for CI smoke tests.
 """
 import argparse
-import subprocess
+import os
+import json
 from pathlib import Path
+import pandas as pd
+import numpy as np
+import yaml
+from src.backtest.backtester import VectorBacktester
 
-def run(cmd):
-    print(f"[run] {cmd}")
-    r = subprocess.run(cmd, shell=True)
-    if r.returncode != 0:
-        raise SystemExit(f"Command failed: {cmd}")
+def sample_df(n=300):
+    # Build a tiny synthetic minute OHLCV series for smoke-run
+    idx = pd.date_range(end=pd.Timestamp.utcnow().floor('T'), periods=n, freq='T')
+    price = 50000 + np.cumsum(np.random.normal(0, 1, size=n))
+    df = pd.DataFrame({
+        'timestamp': idx,
+        'open': price,
+        'high': price + np.abs(np.random.normal(0, 1, size=n)),
+        'low': price - np.abs(np.random.normal(0, 1, size=n)),
+        'close': price + np.random.normal(0, 0.2, size=n),
+        'volume': np.abs(np.random.normal(1, 0.3, size=n)),
+    }).set_index('timestamp')
+    return df
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("--config", default="configs/backtest.yaml")
-    p.add_argument("--merged", default=None, help="override merged parquet path")
+    p.add_argument('--input', help='Input cleaned CSV (OHLCV)', default=None)
+    p.add_argument('--config', help='Config YAML', default='configs/trade_logic.yaml')
+    p.add_argument('--outdir', help='Output directory', default='artifacts/backtest/run_local')
+    p.add_argument('--sample', help='Run on synthetic sample data', action='store_true')
     args = p.parse_args()
-    cmd = f"python -m src.backtest.backtester --config {args.config}"
-    if args.merged:
-        cmd += f" --merged {args.merged}"
-    run(cmd)
-    print("[run_backtest] done. check artifacts/backtest/ for outputs.")
-    print("[run_backtest] note: to run robustness analyses use scripts/run_robustness.py")
 
-if __name__ == "__main__":
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.config, 'r') as fh:
+        cfg = yaml.safe_load(fh)
+
+    if args.sample or args.input is None:
+        df = sample_df()
+    else:
+        df = pd.read_csv(args.input, parse_dates=['timestamp'], index_col='timestamp')
+
+    # Minimal signals: use simple momentum: compare close to 5-min SMA
+    df['sma5'] = df['close'].rolling(5, min_periods=1).mean()
+    df['signal'] = np.where(df['close'] > df['sma5'], 'BUY', 'FLAT')
+
+    # This will fail if src is not in python path. Let's add it.
+    import sys
+    sys.path.insert(0, os.getcwd())
+    from src.backtest.backtester import VectorBacktester
+
+    bt = VectorBacktester(df=df, config=cfg)
+    trades, equity, summary = bt.run()
+
+    trades.to_csv(outdir / 'trades.csv', index=False)
+    equity.to_csv(outdir / 'equity_curve.csv', index=False)
+    with open(outdir / 'summary.json', 'w') as fh:
+        json.dump(summary, fh, indent=2, default=str)
+
+    print("Backtest complete. Artifacts written to", outdir)
+
+if __name__ == '__main__':
     main()

--- a/src/backtest/backtester.py
+++ b/src/backtest/backtester.py
@@ -1,331 +1,110 @@
-#!/usr/bin/env python3
 """
-Vectorized backtester scaffold for Phase IV.
+Vectorized backtester skeleton.
 
-Key behaviors:
- - Accepts merged features + target parquet (must include timestamp, open, close, ATR columns if using ATR slippage)
- - Produces signals either by loading a saved XGBoost model (JSON) or by reading a signal column
- - Executes trades at next bar open (execution_delay_bars) and applies slippage and fees
- - Vectorized P&L calculation based on bar returns and position fraction allocation
- - Produces trades DataFrame, equity curve, returns series, summary metrics (via src/backtest/metrics.py)
+Main class: VectorBacktester
 
-This is a scaffold — it is conservative, clear, and designed to be iterated upon.
+Inputs:
+- df: pandas DataFrame indexed by timestamp with columns: open/high/low/close/volume and a 'signal' column (BUY/SELL/FLAT)
+- config: dict loaded from YAML (fees, slippage.alpha, execution, backtest)
+Outputs:
+- trades: DataFrame with executed trades
+- equity: DataFrame with equity curve (timestamp, equity)
+- summary: dict
 """
-from __future__ import annotations
-import argparse
-import json
-from pathlib import Path
-from typing import Dict, Tuple, Optional, Any
-import numpy as np
+from dataclasses import dataclass
 import pandas as pd
-import xgboost as xgb
-from datetime import datetime
-from src.backtest.metrics import summary_from_returns
-from src.backtest import model_loaders
-import math
+import numpy as np
+import json
+from typing import Tuple, Dict
 
-# helper
-def load_config(path: str) -> Dict:
-    import yaml
-    with open(path, "r") as f:
-        return yaml.safe_load(f)
+EPS = 1e-12
 
-def load_merged_features(path: str) -> pd.DataFrame:
-    df = pd.read_parquet(path)
-    # ensure timestamp sorted and datetime
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"])
-        df = df.sort_values("timestamp").reset_index(drop=True)
-    return df
+@dataclass
+class VectorBacktester:
+    df: pd.DataFrame
+    config: Dict
 
-def load_xgb_model(model_path: str) -> xgb.Booster:
-    bst = xgb.Booster()
-    bst.load_model(str(model_path))
-    return bst
-
-def predict_with_xgb(bst: xgb.Booster, X: pd.DataFrame, meta: Dict[str, Any], predict_proba: bool=True) -> np.ndarray:
-    # meta expected to contain 'feature_names' and 'enc_to_label' mapping
-    feat_names = meta.get("feature_names", X.columns.tolist())
-    # reindex X to feature_names safely
-    Xm = X.reindex(columns=feat_names).fillna(0.0)
-    dmat = xgb.DMatrix(Xm.values, feature_names=feat_names)
-    preds = bst.predict(dmat)
-    if preds.ndim == 2:
-        # multi-class probabilities
-        if predict_proba:
-            return preds  # shape (n_samples, n_classes)
-        else:
-            return np.argmax(preds, axis=1)
-    else:
-        # binary prob returned as single-column
-        if predict_proba:
-            return np.vstack([1 - preds, preds]).T
-        else:
-            return (preds > 0.5).astype(int)
-
-def decode_preds(preds_enc: np.ndarray, meta: Dict[str, Any]) -> np.ndarray:
-    # meta.enc_to_label expected e.g. {"0": -1, "1": 0, "2": 1}
-    enc_to_label = meta.get("enc_to_label") or meta.get("enc_to_label", {})
-    # ensure keys are strings
-    decoded = []
-    for p in preds_enc:
-        key = str(int(p))
-        decoded.append(int(enc_to_label.get(key, int(p))))
-    return np.array(decoded, dtype=int)
-
-def compute_slippage_percent(row: pd.Series, cfg: Dict) -> float:
-    st = cfg["execution"]["slippage"]["type"]
-    if st == "fixed":
-        return float(cfg["execution"]["slippage"]["fixed_pct"])
-    # atr_fraction: slippage_pct = (atr_next / open_next) * atr_fraction
-    if st == "atr_fraction":
-        # use the atr column if present; else fall back to computed approx
-        atr_col = "atr_14"  # common name from feature builder
-        if atr_col in row:
-            # atr value is in price units, convert to percentage vs open
-            open_p = row.get("open", np.nan)
-            if open_p and open_p > 0:
-                return float((row.get(atr_col, 0.0) / open_p) * cfg["execution"]["slippage"]["atr_fraction"])
-        # fallback
-        return float(cfg["pricing"].get("slippage_alpha", 0.5) * cfg["execution"].get("slippage", {}).get("fixed_pct", 0.0005))
-    return 0.0
-
-def _construct_signals(df: pd.DataFrame, cfg: Dict) -> Tuple[np.ndarray, Optional[np.ndarray]]:
-    """
-    Returns:
-      - signal_labels: array of -1/0/1 (length = len(df))
-      - signal_probs: if model proba available, returns per-class probs (n x k) else None
-    """
-    source = cfg["signals"]["source"]
-    if source == "col":
-        col = cfg["signals"]["col_name"]
-        if col not in df.columns:
-            raise ValueError(f"signal column {col} not present in dataframe")
-        sig = df[col].fillna(0).astype(int).values
-        return sig, None
-    elif source == "model":
-        model_cfg = cfg["signals"]["model"]
-        mtype = model_cfg.get("type", "xgboost")
-        # prepare feature-only matrix for model inputs (drop obvious price/time cols)
-        X = df.select_dtypes(include=[np.number]).copy()
-        for dropc in ["open", "high", "low", "close", "volume", "timestamp"]:
-            if dropc in X.columns:
-                X = X.drop(columns=[dropc])
-        if mtype == "xgboost":
-            model_path = model_cfg["path"]
-            meta_path = model_cfg.get("meta")
-            bst, meta = model_loaders.load_xgb_model_and_meta(model_path, meta_path)
-            labels_enc, probs = model_loaders.predict_xgb(bst, X, meta, predict_proba=model_cfg.get("predict_proba", True))
-            # decode using meta.enc_to_label if present
-            enc_to_label = meta.get("enc_to_label", {})
-            if enc_to_label:
-                labels = np.array([int(enc_to_label.get(str(int(v)), int(v))) for v in labels_enc], dtype=int)
+    def __post_init__(self):
+        required = ['open', 'high', 'low', 'close', 'volume']
+        for c in required:
+            if c not in self.df.columns:
+                raise ValueError(f"input df missing required column {c}")
+        self.df = self.df.copy()
+        # ensure datetime index
+        if not isinstance(self.df.index, pd.DatetimeIndex):
+            if 'timestamp' in self.df.columns:
+                self.df = self.df.set_index(pd.to_datetime(self.df['timestamp']))
             else:
-                labels = labels_enc
-            return labels, probs
-        elif mtype == "lstm":
-            # LSTM: require paths in config.models.lstm
-            lstm_cfg = cfg.get("models", {}).get("lstm", {})
-            model_path = lstm_cfg.get("model_path") or model_cfg.get("path")
-            scaler_path = lstm_cfg.get("scaler_path")
-            label_map = lstm_cfg.get("label_map")
-            seq_len = int(lstm_cfg.get("seq_len", 60))
-            batch_size = int(lstm_cfg.get("batch_size", 512))
-            art = model_loaders.load_lstm_artifact(model_path, scaler_path, label_map, device="cpu")
-            # pass numeric X into LSTM predictor
-            labels, probs = model_loaders.predict_lstm(art, X, seq_len=seq_len, batch_size=batch_size)
-            return labels, probs
-        else:
-            raise ValueError(f"unsupported model type for signals: {mtype}")
-    else:
-        raise ValueError("unknown signals.source config")
+                raise ValueError("df must have DatetimeIndex or timestamp column")
+        # create ATR for slippage model
+        self.df['tr'] = np.maximum(self.df['high'] - self.df['low'],
+                                   np.maximum((self.df['high'] - self.df['close'].shift(1)).abs(),
+                                              (self.df['low'] - self.df['close'].shift(1)).abs()))
+        self.df['atr'] = self.df['tr'].rolling(14, min_periods=1).mean().fillna(0)
 
-def vectorized_backtest(df: pd.DataFrame, cfg: Dict) -> Dict:
-    """
-    Core vectorized backtest logic.
+    def map_signal_to_target(self, s: pd.Series) -> pd.Series:
+        mapping = self.config.get('backtest', {}).get('signal_to_position', {'BUY':1,'SELL':-1,'FLAT':0})
+        return s.map(mapping).fillna(0).astype(float)
 
-    Returns a dict with:
-      - equity_curve (pd.Series indexed by timestamp)
-      - returns_series (np.array)
-      - trades (pd.DataFrame)
-      - summary (dict)
-    """
-    # basic params
-    capital = float(cfg["capital"]["initial_capital"])
-    position_fraction = float(cfg["capital"]["position_fraction"])
-    exec_delay = int(cfg["execution"]["execution_delay_bars"])
-    maker_fee = float(cfg["execution"]["fee"]["maker_fee_pct"])
-    taker_fee = float(cfg["execution"]["fee"]["taker_fee_pct"])
-    out_dir = Path(cfg["outputs"]["out_dir"])
-    out_dir.mkdir(parents=True, exist_ok=True)
+    def compute_execution_price(self) -> pd.Series:
+        # execution at next-open + alpha * ATR_next
+        alpha = float(self.config.get('slippage', {}).get('alpha', 0.5))
+        # use next open and next atr
+        next_open = self.df['open'].shift(-1)
+        next_atr = self.df['atr'].shift(-1).ffill().fillna(0.0)
+        exec_price = next_open + alpha * next_atr
+        # if next_open is NaN (end of series), fallback to current close
+        exec_price = exec_price.fillna(self.df['close'])
+        return exec_price
 
-    df = df.copy().reset_index(drop=True)
-    n = len(df)
-    # build signals
-    signal_labels, signal_probs = _construct_signals(df, cfg)
-    df["signal"] = signal_labels
+    def run(self) -> Tuple[pd.DataFrame, pd.DataFrame, Dict]:
+        df = self.df.copy()
+        if 'signal' not in df.columns:
+            raise ValueError("df must contain a 'signal' column before running the backtester")
 
-    # positions are fraction of equity allocated with sign (-1/0/1)
-    pos_frac = (signal_labels.astype(float) * position_fraction)
-    # applied position after execution delay (shift forward)
-    applied_pos = np.concatenate([np.zeros(exec_delay), pos_frac[:-exec_delay]]) if exec_delay > 0 else pos_frac.copy()
+        df['target_pos'] = self.map_signal_to_target(df['signal'])
+        df['target_pos_prev'] = df['target_pos'].shift(1).fillna(0.0)
+        df['trade_qty'] = df['target_pos'] - df['target_pos_prev']
 
-    # compute bar returns (open -> close) as fractional returns
-    open_p = df[cfg["input"]["price_column_open"]].values
-    close_p = df[cfg["input"]["price_column_close"]].values
-    # bar return: (close / open) - 1, avoid divide by zero
-    bar_ret = np.where(open_p > 0, (close_p / open_p) - 1.0, 0.0)
+        df['exec_price'] = self.compute_execution_price()
 
-    # slippage percent per bar (uses next bar atr/open if possible). We'll compute per-row slippage_pct
-    slippage_pct = np.zeros(n)
-    for i in range(n):
-        slippage_pct[i] = compute_slippage_percent(df.iloc[i].to_dict() if hasattr(df.iloc[i], "to_dict") else df.iloc[i], cfg)
+        df['notional'] = df['trade_qty'] * df['exec_price']
 
-    # trade events where applied_pos changes
-    applied_pos_series = pd.Series(applied_pos)
-    pos_change = applied_pos_series.diff().fillna(applied_pos_series).values != 0
+        min_notional = float(self.config.get('execution', {}).get('min_notional', 0.0))
+        is_trade = (df['notional'].abs() >= min_notional) & (df['trade_qty'] != 0)
 
-    # trade cost vector: when a trade occurs (entry or exit), apply taker fee on notional = position_fraction * price
-    # approximate monetary cost per bar relative to equity = fee_pct * position_fraction
-    trade_cost_pct = np.zeros(n)
-    for i in range(n):
-        if pos_change[i]:
-            # determine if entering or exiting; apply taker_fee for both entry and exit events (conservative)
-            trade_cost_pct[i] = taker_fee * abs(applied_pos[i]) / (position_fraction if position_fraction>0 else 1.0)
-        else:
-            trade_cost_pct[i] = 0.0
+        fees_cfg = self.config.get('fees', {})
+        taker_fee = float(fees_cfg.get('taker', 0.0004))
+        df['fees'] = df['notional'].abs() * taker_fee
 
-    # slippage cost as percent of price applied at entries as well (approx)
-    slippage_cost_pct = pos_change * slippage_pct
+        df['cash_flow'] = -df['notional'] - df['fees']
 
-    # strategy returns per bar as fraction of equity:
-    # strategy_return_pct = applied_pos * bar_ret - trade_cost_pct - slippage_cost_pct
-    strat_ret = applied_pos * bar_ret - trade_cost_pct - slippage_cost_pct
+        initial_cash = 100000.0
+        df['position'] = df['trade_qty'].where(is_trade, 0).cumsum()
+        df['cash'] = initial_cash + df['cash_flow'].where(is_trade, 0).cumsum()
+        df['equity'] = df['cash'] + df['position'] * df['close']
 
-    # equity curve
-    equity = [capital]
-    for r in strat_ret:
-        equity.append(equity[-1] * (1.0 + float(r)))
-    equity = pd.Series(equity[1:], index=df["timestamp"])
+        trades_df = df.loc[is_trade].copy()
+        trades_df.rename(columns={'trade_qty': 'qty', 'exec_price': 'price'}, inplace=True)
+        trades_df['timestamp'] = trades_df.index
+        trades_df['cash_after'] = trades_df['cash']
+        trades_df['position_after'] = trades_df['position']
+        trades_df = trades_df[['timestamp', 'qty', 'price', 'notional', 'cash_after', 'position_after']]
 
-    # build trades DataFrame (iterative over pos changes)
-    trades = []
-    current_entry = None
-    for i in range(n):
-        if pos_change[i]:
-            ts = df.loc[i, "timestamp"]
-            sign = np.sign(applied_pos[i])
-            price = open_p[i]  # approximate execution at open
-            slippage = slippage_pct[i] * price
-            exec_price = price + (slippage * sign)
-            if current_entry is None and sign != 0:
-                # entry
-                current_entry = {
-                    "entry_index": i,
-                    "entry_time": ts,
-                    "side": int(sign),
-                    "entry_price": float(exec_price),
-                    "size_fraction": abs(applied_pos[i]),
-                }
-            elif current_entry is not None:
-                # exit existing trade, record
-                exit_price = exec_price
-                pnl = (exit_price - current_entry["entry_price"]) * current_entry["side"] * (capital * current_entry["size_fraction"] / current_entry["entry_price"])
-                trades.append({
-                    "entry_time": current_entry["entry_time"],
-                    "exit_time": ts,
-                    "side": current_entry["side"],
-                    "entry_price": current_entry["entry_price"],
-                    "exit_price": float(exit_price),
-                    "pnl": float(pnl),
-                    "size_fraction": current_entry["size_fraction"],
-                })
-                # if new sign is non-zero, start new entry
-                if sign != 0:
-                    current_entry = {
-                        "entry_index": i,
-                        "entry_time": ts,
-                        "side": int(sign),
-                        "entry_price": float(exec_price),
-                        "size_fraction": abs(applied_pos[i]),
-                    }
-                else:
-                    current_entry = None
-    # if a position still open at end, close at last bar close
-    if current_entry is not None:
-        ts = df.loc[n-1, "timestamp"]
-        price = close_p[-1]
-        sign = current_entry["side"]
-        exit_price = price
-        pnl = (exit_price - current_entry["entry_price"]) * current_entry["side"] * (capital * current_entry["size_fraction"] / current_entry["entry_price"])
-        trades.append({
-            "entry_time": current_entry["entry_time"],
-            "exit_time": ts,
-            "side": current_entry["side"],
-            "entry_price": current_entry["entry_price"],
-            "exit_price": float(exit_price),
-            "pnl": float(pnl),
-            "size_fraction": current_entry["size_fraction"],
-        })
+        equity_df = df[['equity', 'cash', 'position']].copy()
+        equity_df['timestamp'] = equity_df.index
+        equity_df = equity_df[['timestamp', 'equity', 'cash', 'position']]
 
-    trades_df = pd.DataFrame(trades)
+        returns = equity_df['equity'].pct_change().fillna(0.0)
+        avg_ret = float(returns.mean())
+        vol = float(returns.std())
+        sharpe = float((avg_ret / (vol + EPS)) * np.sqrt(252*24*60)) if vol > 0 else 0.0
 
-    # compute returns series as percent returns over periods from equity
-    returns = equity.pct_change().fillna(0.0).values
+        summary = {
+            'start_equity': float(equity_df['equity'].iloc[0]) if not equity_df.empty else 0.0,
+            'end_equity': float(equity_df['equity'].iloc[-1]) if not equity_df.empty else 0.0,
+            'total_trades': int(len(trades_df)),
+            'sharpe_minute_annualized_rough': sharpe
+        }
 
-    # metrics
-    # period_per_year: use minutes-per-year (approx)
-    period_per_year = 365 * 24 * 60
-    summary = summary_from_returns(equity, returns, trades_df, period_per_year)
-
-    # save artifacts if requested
-    out_dir = Path(cfg["outputs"]["out_dir"])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    if cfg["outputs"].get("save_equity_csv", True):
-        eq_df = pd.DataFrame({"timestamp": equity.index, "equity": equity.values})
-        eq_df.to_csv(out_dir / "equity_curve.csv", index=False)
-    if cfg["outputs"].get("save_trades_csv", True):
-        trades_df.to_csv(out_dir / "trades.csv", index=False)
-    if cfg["outputs"].get("save_summary_json", True):
-        with open(out_dir / "summary.json", "w") as f:
-            json.dump(summary, f, indent=2)
-
-    return {
-        "equity": equity,
-        "returns": returns,
-        "trades": trades_df,
-        "summary": summary,
-    }
-
-def main(argv=None):
-    p = argparse.ArgumentParser()
-    p.add_argument("--config", default="configs/backtest.yaml", help="backtest config yaml")
-    p.add_argument("--merged", default=None, help="override merged features parquet")
-    args = p.parse_args(argv)
-    cfg = load_config(args.config)
-    if args.merged:
-        cfg["backtest"]["input"]["merged_features"] = args.merged
-    merged_path = cfg["backtest"]["input"]["merged_features"]
-    df = load_merged_features(merged_path)
-    # transfer cfg into easier structure (backtest.* -> top-level)
-    # flatten names for backward compat
-    flat_cfg = {}
-    flat_cfg.update(cfg["backtest"])
-    flat_cfg.update(cfg.get("backtest", {}))
-    # include other top-level nodes
-    flat_cfg["execution"] = cfg.get("backtest", {}).get("execution", cfg.get("execution", cfg.get("backtest", {}).get("execution", {})))
-    # add signals and capital info
-    # we support both 'signals' under config root and under backtest
-    if "signals" not in flat_cfg:
-        flat_cfg["signals"] = cfg.get("backtest", {}).get("signals", cfg.get("signals", {}))
-    if "capital" not in flat_cfg:
-        flat_cfg["capital"] = cfg.get("backtest", {}).get("capital", cfg.get("capital", {}))
-    # set outputs
-    flat_cfg["outputs"] = cfg.get("backtest", {}).get("outputs", cfg.get("outputs", {}))
-    # pass df and flattened cfg
-    res = vectorized_backtest(df, flat_cfg)
-    print("[backtest] summary:", json.dumps(res["summary"], indent=2))
-    print(f"[backtest] saved artifacts to {flat_cfg['outputs']['out_dir']}")
-
-if __name__ == "__main__":
-    main()
+        return trades_df, equity_df, summary


### PR DESCRIPTION
## Summary

This PR introduces a Python backend CLI with supporting modules for analysis.

## Features
- Ingest Binance CSVs
- Compute technical indicators
- Run local LLM inference (quantised when possible)
- Run a toy LoRA training job
- Fetch historical klines from Binance
- Run a naive backtest

## Setup (macOS Quickstart)
```bash
cd backend
python3 -m venv .venv
source .venv/bin/activate
python -m pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
